### PR TITLE
fix Problem Description being funky on mobile

### DIFF
--- a/_posts/2022-10-16-sekai-vocaloid-heardle.md
+++ b/_posts/2022-10-16-sekai-vocaloid-heardle.md
@@ -27,11 +27,11 @@ Well, it’s just too usual to hide a flag in stegano, database, cipher, or serv
 
 ## Problem Description
 
-> Well, it’s just too usual to hide a flag in stegano, database, cipher, or server. What if we decide to sing it out instead?
->
-> Author: pamLELcu
->
-> See challenge here: https://ctf.sekai.team/challenges#Vocaloid-Heardle-23
+Well, it’s just too usual to hide a flag in stegano, database, cipher, or server. What if we decide to sing it out instead?
+
+Author: pamLELcu
+
+See challenge here: https://ctf.sekai.team/challenges#Vocaloid-Heardle-23
 
 ## Files Provided
 


### PR DESCRIPTION
On mobile the Problem Description looks like this (which is probably due to '>' not rendering well). 

Proposed change: remove '>' 

![image](https://user-images.githubusercontent.com/58854510/199828455-bd3717ca-32b5-4c7c-89e8-4d4e34c2dc5c.png)
